### PR TITLE
Update install-build-dependencies-debian-unstable.sh

### DIFF
--- a/install-build-dependencies-debian-unstable.sh
+++ b/install-build-dependencies-debian-unstable.sh
@@ -50,7 +50,8 @@ apt install \
     libltdl-dev \
     liblzo2-dev \
     libmicrohttpd-dev \
-    libmysqlclient-dev \
+    libmariadb-dev-compat \
+    libmariadb-dev \
     libnfs-dev \
     libogg-dev \
     libpcre3-dev \


### PR DESCRIPTION
In Debian 9 mysql was replaced with mariadb, it should be compatible tho.